### PR TITLE
Release v1.0.20220221

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure               {:mvn/version "1.10.3"}
     org.babashka/sci                  {:mvn/version "0.3.1"}
-    com.github.pmonks/discljord-utils {:mvn/version "1.0.64"}}
+    com.github.pmonks/discljord-utils {:mvn/version "1.0.67"}}
  :aliases
    {:build {:deps       {io.github.seancorfield/build-clj {:git/tag "v0.6.7" :git/sha "22c2d09"}
                          com.github.pmonks/pbr            {:mvn/version "RELEASE"}}

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "f542e0fcf8d3a56609ca0e433270db0a028517c9",
- :date #inst "2022-02-22T04:48:20.407-00:00",
+{:hash "32d63298c9d6ada5c968b1499976baba11976783",
+ :date #inst "2022-02-22T05:04:13.766-00:00",
  :repo "https://github.com/pmonks/for-science.git",
  :tag "1.0.20220221"}


### PR DESCRIPTION
org.github.pmonks/for-science release v1.0.20220221. See commit log for details of what's included in this release.