### PR TITLE
Release 1.0.20220919

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  :deps
    {org.clojure/clojure               {:mvn/version "1.11.1"}
     org.babashka/sci                  {:mvn/version "0.4.33"}
-    com.github.pmonks/discljord-utils {:mvn/version "1.0.87"}}
+    com.github.pmonks/discljord-utils {:mvn/version "1.0.91"}}
  :aliases
    {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
                          com.github.pmonks/pbr         {:mvn/version "RELEASE"}}

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "3060abc1a197d7b636b50a06f7f151467538bf9e",
- :date #inst "2022-09-20T00:44:18.785-00:00",
+{:hash "098e2d88e6639947af90a84f2bb1200eebab1e66",
+ :date #inst "2022-09-20T01:09:36.725-00:00",
  :repo "https://github.com/pmonks/for-science.git",
  :tag "1.0.20220919"}


### PR DESCRIPTION
org.github.pmonks/for-science release 1.0.20220919. See commit log for details of what's included in this release.