### PR TITLE
Release 1.0.20230819

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,7 @@
     org.babashka/sci                  {:mvn/version "0.8.40"}
     com.github.pmonks/discljord-utils {:mvn/version "1.0.91"}}
  :aliases
-   {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
+   {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.5" :git/sha "24f2894"}
                          com.github.pmonks/pbr         {:mvn/version "RELEASE"}}
             :ns-default pbr.build}
 

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "b13c2d81de0536e099ad915320d00d05d8765095",
- :date #inst "2023-07-05T22:22:36.403-00:00",
+{:hash "f93216cae1a5bce8ad3908010f8c170e7e7ab3b6",
+ :date #inst "2023-08-19T20:04:05.219-00:00",
  :repo "https://github.com/pmonks/for-science.git",
- :tag "1.0.20230705"}
+ :tag "1.0.20230819"}


### PR DESCRIPTION
org.github.pmonks/for-science release 1.0.20230819. See commit log for details of what's included in this release.