### PR TITLE
Release 1.0.20260209 (manual)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,133 +1,150 @@
 
-# Contributor Covenant Code of Conduct
+# Contributor Covenant 3.0 Code of Conduct
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We are committed to fostering an environment that respects and promotes the dignity, rights,
+and contributions of all individuals, regardless of characteristics including race, ethnicity,
+caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender
+identity or expression, sexual orientation, language, philosophy or religion, national or
+social origin, socio-economic position, level of education, or other status. The same
+privileges of participation are extended to everyone who participates in good faith and in
+accordance with this Covenant.
 
-## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+## Encouraged Behaviors
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
-  community
+While acknowledging differences in social norms, we all strive to meet our community's
+expectations for positive behavior. We also understand that our words and actions may be
+interpreted differently than we intend based on culture, background, or native language.
 
-Examples of unacceptable behavior include:
+With these considerations in mind, we agree to behave mindfully toward each other and act in
+ways that center our shared values, including:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
-  any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
-  without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+## Restricted Behaviors
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+We agree to restrict the following behaviors in our community. Instances, threats, and
+promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary
+   personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a
+   community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the
+   basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately
+   intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private
+   information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any
+   person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be
+   someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you
+   contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is
+   outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes,
+   links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to
+collaborate. Not every conflict represents a code of conduct violation, and this Code of
+Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize
+harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible
+violation, please email [pmonks+conduct@gmail.com](mailto:pmonks+conduct@gmail.com?subject=Reporting%20a%20possible%20Code%20of%20Conduct%20violation).
+
+Community Moderators take reports of violations seriously and will make every effort to
+respond in a timely manner. They will investigate all reports of code of conduct violations,
+reviewing messages, logs, and recordings, or interviewing witnesses and other participants.
+Community Moderators will keep investigation and enforcement actions as transparent as
+possible while prioritizing safety and confidentiality. In order to honor these values,
+enforcement actions are carried out in private with the involved parties, but communicating to
+the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been
+violated, the following enforcement ladder may be used to determine how best to repair harm,
+based on the incident's impact on the individuals involved and the community as a whole.
+Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of
+      responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the
+      first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to
+      underscore the seriousness of the situation and give the community members involved time
+      to process the incident. The cooldown period may be limited to particular communication
+      channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to
+      reflect on actions and impact, and being thoughtful about re-entering community spaces
+      after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to
+      address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In
+      general, temporary suspensions give the person being suspended time to reflect upon
+      their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the
+      specified conditions for return, and being thoughtful about how to reintegrate with the
+      community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder
+      have failed to resolve, or a violation so serious that the Community Moderators
+      determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is
+      removed. In general, permanent bans should be rarely used, should have strong reasoning
+      behind them, and should only be resorted to if working through other remedies has failed
+      to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community
+Managers to use their discretion and judgment, in keeping with the best interests of our
+community.
+
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual
+is officially representing the community in public or other spaces. Examples of representing
+our community include using an official email address, posting via an official social media
+account, or acting as an appointed representative at an online or offline event.
 
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[pmonks+conduct@gmail.com](mailto:pmonks+conduct@gmail.com?subject=Code%20of%20Conduct%20Report).
-All complaints will be reviewed and investigated promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
-
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of
-actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently
+available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under
+CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
+Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).
+The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 25
-      - uses: DeLaGuardo/setup-clojure@13.4
+      - uses: DeLaGuardo/setup-clojure@13
         with:
           cli: latest
       - uses: actions/cache@v5

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
 {:paths ["src" "resources"]
  :deps
    {org.clojure/clojure               {:mvn/version "1.12.4"}
-    org.babashka/sci                  {:mvn/version "0.11.50"}
+    org.babashka/sci                  {:mvn/version "0.12.51"}
     com.github.pmonks/rencg           {:mvn/version "1.0.64"}
     com.github.pmonks/discljord-utils {:mvn/version "1.0.137"}}
  :aliases

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "03e67ad179bdce02a081588bff3e73254009fda5",
- :date #inst "2025-12-25T00:39:54.835-00:00",
+{:hash "054919a774405aa4a9afc18b251933f73dae8f41",
+ :date #inst "2026-02-09T23:23:37.852-00:00",
  :repo "https://github.com/pmonks/for-science.git",
- :tag "1.0.20251224"}
+ :tag "1.0.20260209"}


### PR DESCRIPTION
org.github.pmonks/for-science release 1.0.20260209. See commit log for details of what's included in this release.

This release PR had to be manually created because of GitHub's incompetence in maintaining their `hub` command line tool (it no longer authenticates using a personal access token).