### PR TITLE
org.github.pmonks/for-science release 1.0.20260719

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -25,7 +25,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@13
         with:
           cli: latest
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,5 +11,5 @@ jobs:
     container:
       image: uochan/antq
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: java -jar /tmp/antq/antq.jar --skip=pom --exclude=com.github.pmonks/pbr --error-format="::error file={{file}}::{{message}}"

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
 {:paths ["src" "resources"]
  :deps
    {org.clojure/clojure               {:mvn/version "1.12.5"}
-    org.babashka/sci                  {:mvn/version "0.13.53"}
+    org.babashka/sci                  {:mvn/version "0.15.56"}
     com.github.pmonks/rencg           {:mvn/version "1.0.90"}
     com.github.pmonks/discljord-utils {:mvn/version "1.0.137"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
 {:paths ["src" "resources"]
  :deps
    {org.clojure/clojure               {:mvn/version "1.12.5"}
-    org.babashka/sci                  {:mvn/version "0.13.52"}
+    org.babashka/sci                  {:mvn/version "0.13.53"}
     com.github.pmonks/rencg           {:mvn/version "1.0.90"}
     com.github.pmonks/discljord-utils {:mvn/version "1.0.137"}}
  :aliases

--- a/resources/build-info.edn
+++ b/resources/build-info.edn
@@ -1,4 +1,4 @@
-{:hash "f5b765b019d438fc5a58585b745c3bf116791a6e",
- :date #inst "2026-06-18T05:30:39.548-00:00",
+{:hash "f20a1e3097dbd3ca5898dd98d22af173121a9e1a",
+ :date #inst "2026-07-19T19:12:24.027-00:00",
  :repo "https://github.com/pmonks/for-science.git",
- :tag "1.0.20260618"}
+ :tag "1.0.20260719"}


### PR DESCRIPTION
org.github.pmonks/for-science release 1.0.20260719. See commit log for details of what's included in this release.